### PR TITLE
Fix `go mod vendor` issue

### DIFF
--- a/bench/gen.go
+++ b/bench/gen.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ingore
+// +build ignore
 
 package main
 

--- a/gen_helper.go
+++ b/gen_helper.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ingore
+// +build ignore
 
 package main
 
@@ -117,6 +117,6 @@ func parseCMakeListsTxt(filename, varname, ext string) (ss []string) {
 	return
 }
 
-func findFiles(dir, ext string) ([]string, error){
+func findFiles(dir, ext string) ([]string, error) {
 	return filepath.Glob(fmt.Sprintf("%s/%s", dir, ext))
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@
 // Use of this source code is governed by a Apache-style
 // license that can be found in the LICENSE file.
 
-module "github.com/chai2010/webp"
+module github.com/chai2010/webp
+
+go 1.17
+
+require golang.org/x/image v0.0.0-20211028202545-6944b10bf410

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410 h1:hTftEOvwiOq2+O8k2D5/Q7COC7k5Qcrgc2TFURJYnvQ=
+golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/hello.go
+++ b/hello.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ingore
+// +build ignore
 
 package main
 

--- a/webp.go
+++ b/webp.go
@@ -7,7 +7,12 @@ package webp
 import (
 	"image"
 	"strings"
+
+	"embed"
 )
+
+//go:embed internal
+var _ embed.FS
 
 const (
 	maxWebpHeaderSize = 32

--- a/webp_decode.go
+++ b/webp_decode.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ingore
+// +build ignore
 
 package webp
 

--- a/webp_decode_test.go
+++ b/webp_decode_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ingore
+// +build ignore
 
 package webp
 


### PR DESCRIPTION
To fix issue: https://github.com/chai2010/webp/issues/38

Verified changes through `go mod vendor`, folder `internal` is included:
![image](https://user-images.githubusercontent.com/17573679/148722006-7250bc87-fbde-4504-a08b-dee12aac1f8a.png)
