### PR TITLE
cgo: silence false-positive clang warning

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -4,6 +4,7 @@
 
 package webp
 
+// #cgo CFLAGS: -Wno-xor-used-as-pow
 //#include "webp.h"
 import "C"
 import "unsafe"


### PR DESCRIPTION
Every build with Clang spits out this annoying warning message:

```
# github.com/chai2010/webp
In file included from z_libwebp_src_enc_picture_csp_enc.c:9: ../../../../go/pkg/mod/github.com/chai2010/webp@v1.1.1/internal/libwebp-1.0.2/src/enc/picture_csp_enc.c:1002:40: warning: result of '2 ^ ALPHA_OFFSET' is 1; did you mean '1 << ALPHA_OFFSET' (8)? [-Wxor-used-as-pow]
```

This commits silences that warning by supplying the requisite CFLAG.

Signed-off-by: Jack Mordaunt <jackmordaunt.dev@gmail.com>