### PR TITLE
fix the 2^x error raise in complier

### DIFF
--- a/capi.go
+++ b/capi.go
@@ -15,8 +15,8 @@
 package webp
 
 /*
-#cgo CFLAGS: -I./internal/libwebp-1.0.2/
-#cgo CFLAGS: -I./internal/libwebp-1.0.2/src/
+#cgo CFLAGS: -I./internal/libwebp-1.0.2/ -w
+#cgo CFLAGS: -I./internal/libwebp-1.0.2/src/ -w
 #cgo CFLAGS: -I./internal/include/
 #cgo CFLAGS: -Wno-pointer-sign -DWEBP_USE_THREAD
 #cgo !windows LDFLAGS: -lm


### PR DESCRIPTION
![image](https://github.com/chai2010/webp/assets/92676541/bfd836b7-57c3-400e-8071-87a54c2520a3)
we're using this repo and encountering this error when building our code and running our test case. So want to fix this by this PR.